### PR TITLE
feat: add localization support and new forbidden response middleware

### DIFF
--- a/Myrtus.Clarity.sln
+++ b/Myrtus.Clarity.sln
@@ -78,6 +78,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Myrtus.Clarity.Core.Applica
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Myrtus.Clarity.SeedData", "src\Myrtus.Clarity.SeedData\Myrtus.Clarity.SeedData.csproj", "{306AC906-EBED-4F1C-94C8-7C7ECEFBDFE7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Myrtus.Clarity.Core.Application.Abstractions.Localization", "core\Myrtus.Clarity.Core.Application.Abstractions.Localization\Myrtus.Clarity.Core.Application.Abstractions.Localization.csproj", "{3C40CE12-A2DF-4BC3-95B8-2CA25BBB06DA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Myrtus.Clarity.Core.Infrastructure.Localization", "core\Myrtus.Clarity.Core.Infrastructure.Localization\Myrtus.Clarity.Core.Infrastructure.Localization.csproj", "{4C004762-BB82-40EC-A6AD-A8C62DE63A25}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -212,6 +216,14 @@ Global
 		{306AC906-EBED-4F1C-94C8-7C7ECEFBDFE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{306AC906-EBED-4F1C-94C8-7C7ECEFBDFE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{306AC906-EBED-4F1C-94C8-7C7ECEFBDFE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C40CE12-A2DF-4BC3-95B8-2CA25BBB06DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C40CE12-A2DF-4BC3-95B8-2CA25BBB06DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C40CE12-A2DF-4BC3-95B8-2CA25BBB06DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C40CE12-A2DF-4BC3-95B8-2CA25BBB06DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C004762-BB82-40EC-A6AD-A8C62DE63A25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C004762-BB82-40EC-A6AD-A8C62DE63A25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C004762-BB82-40EC-A6AD-A8C62DE63A25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C004762-BB82-40EC-A6AD-A8C62DE63A25}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -248,6 +260,8 @@ Global
 		{3C986F15-31D7-49BF-B62B-45B42C817BC2} = {ED5CDE04-7D40-4CC8-BB06-B2949158F655}
 		{116366DC-6E1B-4075-BE48-27E2BA798403} = {ED5CDE04-7D40-4CC8-BB06-B2949158F655}
 		{306AC906-EBED-4F1C-94C8-7C7ECEFBDFE7} = {4736657B-5DD3-4C41-9B25-8F896C590C13}
+		{3C40CE12-A2DF-4BC3-95B8-2CA25BBB06DA} = {ED5CDE04-7D40-4CC8-BB06-B2949158F655}
+		{4C004762-BB82-40EC-A6AD-A8C62DE63A25} = {ED5CDE04-7D40-4CC8-BB06-B2949158F655}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7949CCE5-84CB-4073-9DF1-B959B76413D5}

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -15,5 +15,6 @@
     </None>
     <None Include="docker-compose.yml" />
     <None Include=".dockerignore" />
+    <None Include="src\Myrtus.Clarity.WebAPI\Middleware\ForbiddenResponseMiddleware.cs" />
   </ItemGroup>
 </Project>

--- a/src/Myrtus.Clarity.Infrastructure/DependencyInjection.cs
+++ b/src/Myrtus.Clarity.Infrastructure/DependencyInjection.cs
@@ -74,6 +74,8 @@ namespace Myrtus.Clarity.Infrastructure
 
             AddSignalR(services);
 
+            //AddLocalization(services);
+
             return services;
         }
 
@@ -206,5 +208,10 @@ namespace Myrtus.Clarity.Infrastructure
             services.AddSignalR();
             services.AddSingleton<IUserIdProvider, DefaultUserIdProvider>();
         }
+
+        //private static void AddLocalization(IServiceCollection services)
+        //{
+        //    services.AddSingleton<ILocalizationService, LocalizationService>();
+        //}
     }
 }

--- a/src/Myrtus.Clarity.Infrastructure/Myrtus.Clarity.Infrastructure.csproj
+++ b/src/Myrtus.Clarity.Infrastructure/Myrtus.Clarity.Infrastructure.csproj
@@ -50,6 +50,15 @@
 	</ItemGroup>
 	
 	<ItemGroup>
+	  <None Update="Resources\en.yaml">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	  <None Update="Resources\tr.yaml">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+	
+	<ItemGroup>
 	  <PackageReference Update="SonarAnalyzer.CSharp" Version="9.32.0.97167">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Myrtus.Clarity.Infrastructure/Resources/en.yaml
+++ b/src/Myrtus.Clarity.Infrastructure/Resources/en.yaml
@@ -1,0 +1,9 @@
+Errors:
+  Forbidden: "You do not have permission to access this resource."
+  User:
+    NotFound: "The user with the specified identifier was not found"
+    InvalidCredentials: "The provided credentials were invalid"
+    IdentityIdNotFound: "The identity id is not accessible"
+  Role:
+    NotFound: "The role with the specified identifier was not found"
+    Overlap: "The current role is overlapping with an existing one"

--- a/src/Myrtus.Clarity.Infrastructure/Resources/tr.yaml
+++ b/src/Myrtus.Clarity.Infrastructure/Resources/tr.yaml
@@ -1,0 +1,9 @@
+Errors:
+  Forbidden: "Bu kaynaða eriþim izniniz yok."
+  User:
+    NotFound: "Belirtilen kimliðe sahip kullanýcý bulunamadý"
+    InvalidCredentials: "Saðlanan kimlik bilgileri geçersiz"
+    IdentityIdNotFound: "Kimlik ID'sine eriþilemiyor"
+  Role:
+    NotFound: "Belirtilen kimliðe sahip rol bulunamadý"
+    Overlap: "Mevcut rol, mevcut olanla çakýþýyor"

--- a/src/Myrtus.Clarity.SeedData/Program.cs
+++ b/src/Myrtus.Clarity.SeedData/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,6 +9,7 @@ using Myrtus.Clarity.Domain;
 using Myrtus.Clarity.Infrastructure;
 using Myrtus.Clarity.Infrastructure.SeedData;
 using Myrtus.Clarity.WebAPI;
+using Myrtus.Clarity.WebAPI.Middleware;
 using Serilog;
 
 namespace Myrtus.Clarity.SeedData
@@ -29,6 +31,8 @@ namespace Myrtus.Clarity.SeedData
                 Guid adminId = await app.SeedUsersDataAsync();
                 await app.SeedRoleUserDataAsync(adminId);
             }
+
+            await host.RunAsync();
         }
 
         static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -43,6 +47,14 @@ namespace Myrtus.Clarity.SeedData
                     services.AddApplication();
                     services.AddInfrastructure(context.Configuration);
                     services.AddWebApi(context.Configuration);
+                })
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.Configure(app =>
+                    {
+                        app.UseMiddleware<ExceptionHandlingMiddleware>();
+                        // Other middleware registrations...
+                    });
                 })
                 .UseSerilog((context, loggerConfig) =>
                     loggerConfig.ReadFrom.Configuration(context.Configuration));

--- a/src/Myrtus.Clarity.WebAPI/DependencyInjection.cs
+++ b/src/Myrtus.Clarity.WebAPI/DependencyInjection.cs
@@ -1,4 +1,6 @@
-﻿using Myrtus.Clarity.Core.WebApi;
+﻿using Myrtus.Clarity.Core.Application.Abstractions.Localization.Services;
+using Myrtus.Clarity.Core.Infrastructure.Localization.Services;
+using Myrtus.Clarity.Core.WebApi;
 
 namespace Myrtus.Clarity.WebAPI;
 
@@ -9,6 +11,7 @@ public static class DependencyInjection
         IConfiguration configuration)
     {
         services.AddScoped<IErrorHandlingService, ErrorHandlingService>();
+        services.AddSingleton<ILocalizationService, LocalizationService>();
 
         return services;
     }

--- a/src/Myrtus.Clarity.WebAPI/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Myrtus.Clarity.WebAPI/Extensions/ApplicationBuilderExtensions.cs
@@ -20,6 +20,11 @@ namespace Myrtus.Clarity.WebAPI.Extensions
             app.UseMiddleware<ExceptionHandlingMiddleware>();
         }
 
+        public static void UseCustomForbiddenRequestHandler(this IApplicationBuilder app)
+        {
+            app.UseMiddleware<ForbiddenResponseMiddleware>();
+        }
+
         public static IApplicationBuilder UseRequestContextLogging(this IApplicationBuilder app)
         {
             app.UseMiddleware<RequestContextLoggingMiddleware>();

--- a/src/Myrtus.Clarity.WebAPI/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/Myrtus.Clarity.WebAPI/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,14 +1,20 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using FluentValidation;
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Myrtus.Clarity.Core.Application.Abstractions.Localization.Services;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
 
 namespace Myrtus.Clarity.WebAPI.Middleware
 {
-    internal sealed class ExceptionHandlingMiddleware(
-            RequestDelegate next,
-            ILogger<ExceptionHandlingMiddleware> logger)
+    public sealed class ExceptionHandlingMiddleware(
+                                RequestDelegate next,
+                                ILogger<ExceptionHandlingMiddleware> logger,
+                                ILocalizationService localizationService)
     {
         private readonly RequestDelegate _next = next;
         private readonly ILogger<ExceptionHandlingMiddleware> _logger = logger;
+        private readonly ILocalizationService _localizationService = localizationService;
 
         private static readonly Action<ILogger, string, Exception> _logError =
             LoggerMessage.Define<string>(
@@ -26,7 +32,8 @@ namespace Myrtus.Clarity.WebAPI.Middleware
             {
                 _logError(_logger, exception.Message, exception);
 
-                ExceptionDetails exceptionDetails = GetExceptionDetails(exception);
+                var language = GetLanguageFromHeader(context);
+                ExceptionDetails exceptionDetails = GetExceptionDetails(exception, language);
 
                 ProblemDetails problemDetails = new()
                 {
@@ -34,6 +41,7 @@ namespace Myrtus.Clarity.WebAPI.Middleware
                     Type = exceptionDetails.Type,
                     Title = exceptionDetails.Title,
                     Detail = exceptionDetails.Detail,
+                    Instance = context.Request.Path
                 };
 
                 if (exceptionDetails.Errors is not null)
@@ -42,26 +50,47 @@ namespace Myrtus.Clarity.WebAPI.Middleware
                 }
 
                 context.Response.StatusCode = exceptionDetails.Status;
+                context.Response.ContentType = "application/json; charset=utf-8";
 
-                await context.Response.WriteAsJsonAsync(problemDetails);
+                var options = new JsonSerializerOptions
+                {
+                    Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                    WriteIndented = true
+                };
+                var json = JsonSerializer.Serialize(problemDetails, options);
+                await context.Response.WriteAsync(json, Encoding.UTF8);
             }
         }
 
-        private static ExceptionDetails GetExceptionDetails(Exception exception)
+        private string GetLanguageFromHeader(HttpContext context)
+        {
+            var acceptLanguageHeader = context.Request.Headers["Accept-Language"].ToString();
+            if (!string.IsNullOrEmpty(acceptLanguageHeader))
+            {
+                var languages = acceptLanguageHeader.Split(',');
+                if (languages.Length > 0)
+                {
+                    return languages[0];
+                }
+            }
+            return CultureInfo.CurrentCulture.Name;
+        }
+
+        private ExceptionDetails GetExceptionDetails(Exception exception, string language)
         {
             return exception switch
             {
                 ValidationException validationException => new ExceptionDetails(
                     StatusCodes.Status400BadRequest,
-                    "ValidationFailure",
+                    "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1",
                     "Validation error",
-                    "One or more validation errors has occurred",
+                    _localizationService.GetLocalizedString("Errors.Validation", language),
                     validationException.Errors),
                 _ => new ExceptionDetails(
                     StatusCodes.Status500InternalServerError,
-                    "ServerError",
+                    "https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1",
                     "Server error",
-                    "An unexpected error has occurred",
+                    _localizationService.GetLocalizedString("Errors.ServerError", language),
                     null)
             };
         }

--- a/src/Myrtus.Clarity.WebAPI/Middleware/ForbiddenResponseMiddleware.cs
+++ b/src/Myrtus.Clarity.WebAPI/Middleware/ForbiddenResponseMiddleware.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Myrtus.Clarity.Core.Application.Abstractions.Localization.Services;
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Myrtus.Clarity.WebAPI.Middleware
+{
+    public class ForbiddenResponseMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<ForbiddenResponseMiddleware> _logger;
+        private readonly ILocalizationService _localizationService;
+
+        public ForbiddenResponseMiddleware(RequestDelegate next, ILogger<ForbiddenResponseMiddleware> logger, ILocalizationService localizationService)
+        {
+            _next = next;
+            _logger = logger;
+            _localizationService = localizationService;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            await _next(context);
+
+            if (context.Response.StatusCode == (int)HttpStatusCode.Forbidden)
+            {
+                _logger.LogWarning("Forbidden request: {Path}", context.Request.Path);
+
+                var language = GetLanguageFromHeader(context);
+                var problemDetails = new ProblemDetails
+                {
+                    Status = (int)HttpStatusCode.Forbidden,
+                    Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3",
+                    Title = "Forbidden",
+                    Detail = _localizationService.GetLocalizedString("Errors.Forbidden", language),
+                    Instance = context.Request.Path
+                };
+
+                context.Response.ContentType = "application/json; charset=utf-8";
+                var options = new JsonSerializerOptions
+                {
+                    Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                    WriteIndented = true
+                };
+                var json = JsonSerializer.Serialize(problemDetails, options);
+                await context.Response.WriteAsync(json, Encoding.UTF8);
+            }
+        }
+
+        private string GetLanguageFromHeader(HttpContext context)
+        {
+            var acceptLanguageHeader = context.Request.Headers["Accept-Language"].ToString();
+            if (!string.IsNullOrEmpty(acceptLanguageHeader))
+            {
+                var languages = acceptLanguageHeader.Split(',');
+                if (languages.Length > 0)
+                {
+                    return languages[0];
+                }
+            }
+            return CultureInfo.CurrentCulture.Name;
+        }
+    }
+}

--- a/src/Myrtus.Clarity.WebAPI/Myrtus.Clarity.WebAPI.csproj
+++ b/src/Myrtus.Clarity.WebAPI/Myrtus.Clarity.WebAPI.csproj
@@ -31,6 +31,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\core\Myrtus.Clarity.Core.Domain.Abstractions\Myrtus.Clarity.Core.Domain.Abstractions.csproj" />
+		<ProjectReference Include="..\..\core\Myrtus.Clarity.Core.Infrastructure.Localization\Myrtus.Clarity.Core.Infrastructure.Localization.csproj" />
 		<ProjectReference Include="..\..\core\Myrtus.Clarity.Core.WebApi\Myrtus.Clarity.Core.WebApi.csproj" />
 		<ProjectReference Include="..\Myrtus.Clarity.Application\Myrtus.Clarity.Application.csproj" />
 		<ProjectReference Include="..\Myrtus.Clarity.Infrastructure\Myrtus.Clarity.Infrastructure.csproj" />

--- a/src/Myrtus.Clarity.WebAPI/Program.cs
+++ b/src/Myrtus.Clarity.WebAPI/Program.cs
@@ -13,8 +13,11 @@ using Myrtus.Clarity.Infrastructure;
 using Myrtus.Clarity.WebAPI;
 using Myrtus.Clarity.WebAPI.Extensions;
 using Myrtus.Clarity.WebAPI.OpenApi;
-using Serilog;
 using System.Text.Json.Serialization;
+using Serilog;
+using Myrtus.Clarity.Core.Application.Abstractions.Localization.Services;
+using Myrtus.Clarity.Core.Infrastructure.Localization.Services;
+using Myrtus.Clarity.WebAPI.Middleware;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -63,7 +66,6 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         };
 
         // settings for SignalR authentication with Azure AD B2C
-
         options.Events = new JwtBearerEvents
         {
             OnMessageReceived = context =>
@@ -80,7 +82,6 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 return Task.CompletedTask;
             }
         };
-
     });
 
 builder.Services.AddDomain(builder.Configuration);
@@ -115,6 +116,8 @@ app.UseRequestContextLogging();
 app.UseSerilogRequestLogging();
 
 app.UseCustomExceptionHandler();
+
+app.UseCustomForbiddenRequestHandler();
 
 app.UseAuthentication();
 


### PR DESCRIPTION
Added new projects for localization and updated solution configuration. Introduced `ForbiddenResponseMiddleware` for handling forbidden requests with localized error messages. Commented out `AddLocalization` in `DependencyInjection.cs` and added localization services in `AddWebApi`. Added localization resources `en.yaml` and `tr.yaml`. Updated `Program.cs` and `ExceptionHandlingMiddleware` to use localization services. Added `ILocalizationService` and its implementation. Updated `ErrorHandlingService` and various classes to support localization. Updated `docker-compose.dcproj` and added new methods for better error handling.