### PR TITLE
feat! Add notification read functionality and update queries

### DIFF
--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -15,6 +15,7 @@
     </None>
     <None Include="docker-compose.yml" />
     <None Include=".dockerignore" />
+    <None Include="src\Myrtus.Clarity.Application\Features\Notifications\Queries\GetAllNotifications\GetAllNotificationsWithUnreadCountResponse.cs" />
     <None Include="src\Myrtus.Clarity.WebAPI\Middleware\ForbiddenResponseMiddleware.cs" />
     <None Include="src\Myrtus.Clarity.WebAPI\Middleware\RateLimitExceededMiddleware.cs" />
   </ItemGroup>

--- a/src/Myrtus.Clarity.Application/Features/AuditLogs/Queries/GetAllAuditLogs/GetAllAuditLogsQueryHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/AuditLogs/Queries/GetAllAuditLogs/GetAllAuditLogsQueryHandler.cs
@@ -14,7 +14,9 @@ namespace Myrtus.Clarity.Application.Features.AuditLogs.Queries.GetAllAuditLogs
 
         public async Task<Result<IPaginatedList<GetAllAuditLogsQueryResponse>>> Handle(GetAllAuditLogsQuery request, CancellationToken cancellationToken)
         {
-            IEnumerable<AuditLog> auditLogs = await _auditLogRepository.GetAllAsync(cancellationToken);
+            IEnumerable<AuditLog> auditLogs = await _auditLogRepository.GetAllAsync(
+                            predicate: null,
+                            cancellationToken: cancellationToken);
 
             List<AuditLog> sortedAuditLogs = auditLogs.OrderByDescending(auditLog => auditLog.Timestamp).ToList();
 

--- a/src/Myrtus.Clarity.Application/Features/AuditLogs/Queries/GetAllAuditLogsDynamic/GetAllAuditLogsDynamicQueryHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/AuditLogs/Queries/GetAllAuditLogsDynamic/GetAllAuditLogsDynamicQueryHandler.cs
@@ -8,13 +8,18 @@ using Myrtus.Clarity.Application.Repositories.NoSQL;
 
 namespace Myrtus.Clarity.Application.Features.AuditLogs.Queries.GetAllAuditLogsDynamic
 {
-    public class GetAllAuditLogsDynamicQueryHandler(INoSqlRepository<AuditLog> auditLogRepository) : IRequestHandler<GetAllAuditLogsDynamicQuery, Result<IPaginatedList<GetAllAuditLogsDynamicQueryResponse>>>
+    public class GetAllAuditLogsDynamicQueryHandler(INoSqlRepository<AuditLog> auditLogRepository) 
+        : IRequestHandler<GetAllAuditLogsDynamicQuery, Result<IPaginatedList<GetAllAuditLogsDynamicQueryResponse>>>
     {
         private readonly INoSqlRepository<AuditLog> _auditLogRepository = auditLogRepository;
 
-        public async Task<Result<IPaginatedList<GetAllAuditLogsDynamicQueryResponse>>> Handle(GetAllAuditLogsDynamicQuery request, CancellationToken cancellationToken)
+        public async Task<Result<IPaginatedList<GetAllAuditLogsDynamicQueryResponse>>> Handle(
+            GetAllAuditLogsDynamicQuery request, 
+            CancellationToken cancellationToken)
         {
-            IEnumerable<AuditLog> auditLogs = await _auditLogRepository.GetAllAsync(cancellationToken);
+            IEnumerable<AuditLog> auditLogs = await _auditLogRepository.GetAllAsync(
+                            predicate: null,
+                            cancellationToken: cancellationToken);
 
             IQueryable<AuditLog> filteredAuditLogs = auditLogs.AsQueryable().ToDynamic(request.DynamicQuery);
 

--- a/src/Myrtus.Clarity.Application/Features/Notifications/Commands/MarkNotificationsAsRead/MarkNotificationsAsReadCommand.cs
+++ b/src/Myrtus.Clarity.Application/Features/Notifications/Commands/MarkNotificationsAsRead/MarkNotificationsAsReadCommand.cs
@@ -1,0 +1,8 @@
+﻿using Myrtus.Clarity.Core.Application.Abstractions.Messaging;
+using Myrtus.Clarity.Core.Domain.Abstractions;
+
+namespace Myrtus.Clarity.Application.Features.Notifications.Commands.MarkNotificationsAsRead
+{
+    public sealed record MarkNotificationsAsReadCommand(
+            CancellationToken CancellationToken) : ICommand<MarkNotificationsAsReadCommandResponse>;
+}

--- a/src/Myrtus.Clarity.Application/Features/Notifications/Commands/MarkNotificationsAsRead/MarkNotificationsAsReadCommandHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Notifications/Commands/MarkNotificationsAsRead/MarkNotificationsAsReadCommandHandler.cs
@@ -1,0 +1,34 @@
+﻿using Ardalis.Result;
+using MediatR;
+using Myrtus.Clarity.Core.Application.Abstractions.Authentication;
+using Myrtus.Clarity.Core.Application.Abstractions.Messaging;
+using Myrtus.Clarity.Core.Application.Abstractions.Notification;
+
+namespace Myrtus.Clarity.Application.Features.Notifications.Commands.MarkNotificationsAsRead
+{
+    public sealed class MarkNotificationsAsReadCommandHandler : ICommandHandler<MarkNotificationsAsReadCommand, MarkNotificationsAsReadCommandResponse>
+    {
+        private readonly INotificationService _notificationService;
+        private readonly IUserContext _userContext;
+
+        public MarkNotificationsAsReadCommandHandler(
+            INotificationService notificationService, 
+            IUserContext userContext)
+        {
+            _notificationService = notificationService;
+            _userContext = userContext;
+        }
+
+        public async Task<Result<MarkNotificationsAsReadCommandResponse>> Handle(
+            MarkNotificationsAsReadCommand request,
+            CancellationToken cancellationToken)
+        {
+            var userId = _userContext.IdentityId.ToString();
+            await _notificationService.MarkNotificationsAsReadAsync(userId,cancellationToken);
+
+            MarkNotificationsAsReadCommandResponse response = new();
+
+            return Result.Success(response);
+        }
+    }
+}

--- a/src/Myrtus.Clarity.Application/Features/Notifications/Commands/MarkNotificationsAsRead/MarkNotificationsAsReadCommandResponse.cs
+++ b/src/Myrtus.Clarity.Application/Features/Notifications/Commands/MarkNotificationsAsRead/MarkNotificationsAsReadCommandResponse.cs
@@ -1,0 +1,4 @@
+﻿namespace Myrtus.Clarity.Application.Features.Notifications.Commands.MarkNotificationsAsRead
+{
+    public sealed class MarkNotificationsAsReadCommandResponse();
+}

--- a/src/Myrtus.Clarity.Application/Features/Notifications/Queries/GetAllNotifications/GetAllNotificationsQuery.cs
+++ b/src/Myrtus.Clarity.Application/Features/Notifications/Queries/GetAllNotifications/GetAllNotificationsQuery.cs
@@ -6,5 +6,5 @@ namespace Myrtus.Clarity.Application.Features.Notifications.Queries.GetAllNotifi
     public sealed record GetAllNotificationsQuery(
         int PageIndex,
         int PageSize,
-        CancellationToken CancellationToken) : IQuery<IPaginatedList<GetAllNotificationsQueryResponse>>;
+        CancellationToken CancellationToken) : IQuery<GetAllNotificationsWithUnreadCountResponse>;
 }

--- a/src/Myrtus.Clarity.Application/Features/Notifications/Queries/GetAllNotifications/GetAllNotificationsQueryResponse.cs
+++ b/src/Myrtus.Clarity.Application/Features/Notifications/Queries/GetAllNotifications/GetAllNotificationsQueryResponse.cs
@@ -9,5 +9,5 @@
           string EntityId,
           DateTime Timestamp,
           string Details,
-          bool IsRread);
+          bool IsRead);
 }

--- a/src/Myrtus.Clarity.Application/Features/Notifications/Queries/GetAllNotifications/GetAllNotificationsWithUnreadCountResponse.cs
+++ b/src/Myrtus.Clarity.Application/Features/Notifications/Queries/GetAllNotifications/GetAllNotificationsWithUnreadCountResponse.cs
@@ -1,0 +1,8 @@
+using Myrtus.Clarity.Core.Application.Abstractions.Pagination;
+
+namespace Myrtus.Clarity.Application.Features.Notifications.Queries.GetAllNotifications
+{
+    public sealed record GetAllNotificationsWithUnreadCountResponse(
+        IPaginatedList<GetAllNotificationsQueryResponse> PaginatedNotifications,
+        int UnreadCount);
+}

--- a/src/Myrtus.Clarity.Application/Repositories/NoSQL/INoSqlRepository.cs
+++ b/src/Myrtus.Clarity.Application/Repositories/NoSQL/INoSqlRepository.cs
@@ -5,7 +5,7 @@ namespace Myrtus.Clarity.Application.Repositories.NoSQL
     public interface INoSqlRepository<T>
     {
         Task<T?> GetAsync(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default);
-        Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default);
+        Task<IEnumerable<T>> GetAllAsync(Expression<Func<T, bool>>? predicate, CancellationToken cancellationToken = default);
         Task AddAsync(T entity, CancellationToken cancellationToken = default);
         Task UpdateAsync(T entity, CancellationToken cancellationToken = default);
         Task DeleteAsync(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default);

--- a/src/Myrtus.Clarity.Infrastructure/Repositories/NoSQL/NoSqlRepository.cs
+++ b/src/Myrtus.Clarity.Infrastructure/Repositories/NoSQL/NoSqlRepository.cs
@@ -18,9 +18,10 @@ namespace Myrtus.Clarity.Infrastructure.Repositories.NoSQL
             return await _collection.Find(predicate).FirstOrDefaultAsync(cancellationToken);
         }
 
-        public async Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<T>> GetAllAsync(Expression<Func<T, bool>>? predicate, CancellationToken cancellationToken = default)
         {
-            return await _collection.Find(_ => true).ToListAsync(cancellationToken);
+            var filter = predicate ?? (_ => true);
+            return await _collection.Find(filter).ToListAsync(cancellationToken);
         }
 
         public async Task AddAsync(T entity, CancellationToken cancellationToken = default)

--- a/src/Myrtus.Clarity.Infrastructure/Repositories/NoSQL/NotificationRepository.cs
+++ b/src/Myrtus.Clarity.Infrastructure/Repositories/NoSQL/NotificationRepository.cs
@@ -14,7 +14,7 @@ namespace Myrtus.Clarity.Infrastructure.Repositories.NoSQL
 
         public async Task<IEnumerable<Notification>> GetByPredicateAsync(Expression<Func<Notification, bool>> predicate, CancellationToken cancellationToken = default)
         {
-            return await _collection.Find(predicate).ToListAsync(cancellationToken);
+            return (await _collection.Find(predicate).ToListAsync(cancellationToken));
         }
     }
 }

--- a/src/Myrtus.Clarity.WebAPI/Controllers/Notifications/MarkNotificationsAsReadRequest.cs
+++ b/src/Myrtus.Clarity.WebAPI/Controllers/Notifications/MarkNotificationsAsReadRequest.cs
@@ -1,0 +1,7 @@
+﻿using Myrtus.Clarity.Core.Domain.Abstractions;
+
+namespace Myrtus.Clarity.WebAPI.Controllers.Notifications
+{
+    public sealed record MarkNotificationsAsReadRequest(
+        ICollection<Guid> NotificationIds);
+}

--- a/src/Myrtus.Clarity.WebAPI/Controllers/Notifications/NotificationsController.cs
+++ b/src/Myrtus.Clarity.WebAPI/Controllers/Notifications/NotificationsController.cs
@@ -3,6 +3,7 @@ using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using Myrtus.Clarity.Application.Features.Notifications.Commands.MarkNotificationsAsRead;
 using Myrtus.Clarity.Application.Features.Notifications.Queries.GetAllNotifications;
 using Myrtus.Clarity.Core.Application.Abstractions.Pagination;
 using Myrtus.Clarity.Core.Infrastructure.Authorization;
@@ -15,7 +16,9 @@ namespace Myrtus.Clarity.WebAPI.Controllers.Notifications
     [ApiVersion(ApiVersions.V1)]
     [Route("api/v{version:apiVersion}/notifications")]
     [EnableRateLimiting("fixed")]
-    public class NotificationsController(ISender sender, IErrorHandlingService errorHandlingService) : BaseController(sender, errorHandlingService)
+    public class NotificationsController(
+        ISender sender,
+        IErrorHandlingService errorHandlingService) : BaseController(sender, errorHandlingService)
     {
         [HttpGet]
         [HasPermission(Permissions.NotificationsRead)]
@@ -25,9 +28,21 @@ namespace Myrtus.Clarity.WebAPI.Controllers.Notifications
             CancellationToken cancellationToken = default)
         {
             GetAllNotificationsQuery query = new(pageIndex, pageSize, cancellationToken);
-            Result<IPaginatedList<GetAllNotificationsQueryResponse>> result = await _sender.Send(query, cancellationToken);
+            Result<GetAllNotificationsWithUnreadCountResponse> result = await _sender.Send(query, cancellationToken);
 
             return !result.IsSuccess ? _errorHandlingService.HandleErrorResponse(result) : Ok(result.Value);
+        }
+
+        [HttpPatch("read")]
+        //[HasPermission(Permissions.NotificationsUpdate)]
+        public async Task<IActionResult> MarkNotificationsAsRead(
+            CancellationToken cancellationToken = default)
+        {
+            MarkNotificationsAsReadCommand command = new(cancellationToken);
+
+            Result<MarkNotificationsAsReadCommandResponse> result = await _sender.Send(command, cancellationToken);
+
+            return !result.IsSuccess ? _errorHandlingService.HandleErrorResponse(result) : Ok();
         }
     }
 }


### PR DESCRIPTION
- Added `GetAllNotificationsWithUnreadCountResponse.cs` for paginated notifications and unread count.
- Modified `GetAllAuditLogsQueryHandler.cs` and `GetAllAuditLogsDynamicQueryHandler.cs` to include a `predicate` parameter in `GetAllAsync`.
- Added `MarkNotificationsAsReadCommand` and `MarkNotificationsAsReadCommandHandler` to mark notifications as read.
- Added `MarkNotificationsAsReadCommandResponse`.
- Updated `GetAllNotificationsQuery` to return `GetAllNotificationsWithUnreadCountResponse`.
- Updated `GetAllNotificationsQueryHandler` to include unread count in the response.
- Fixed typo in `GetAllNotificationsQueryResponse` (`IsRread` to `IsRead`).
- Updated `INoSqlRepository` and its implementation to include a `predicate` parameter in `GetAllAsync`.
- Added `MarkNotificationsAsReadRequest`.
- Updated `NotificationsController` to include a new endpoint for marking notifications as read.
- Added `MarkNotificationsAsReadAsync` in `INotificationService` and its implementation.
- Updated `NotificationService` to use the new `GetAllAsync` method with a `predicate` parameter.