### PR TITLE
refactor: Introduce value objects for User entity properties

### DIFF
--- a/src/Myrtus.Clarity.Application/Features/Accounts/RegisterUser/RegisterUserCommand.cs
+++ b/src/Myrtus.Clarity.Application/Features/Accounts/RegisterUser/RegisterUserCommand.cs
@@ -1,10 +1,11 @@
 ﻿using Myrtus.Clarity.Core.Application.Abstractions.Messaging;
+using Myrtus.Clarity.Domain.Users.ValueObjects;
 
 namespace Myrtus.Clarity.Application.Features.Accounts.RegisterUser
 {
     public sealed record RegisterUserCommand(
-            string Email,
-            string FirstName,
-            string LastName,
+            Email Email,
+            FirstName FirstName,
+            LastName LastName,
             string Password) : ICommand<Guid>;
 }

--- a/src/Myrtus.Clarity.Application/Features/Accounts/RegisterUser/RegisterUserEventHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Accounts/RegisterUser/RegisterUserEventHandler.cs
@@ -24,7 +24,7 @@ namespace Myrtus.Clarity.Application.Features.Accounts.RegisterUser
                 return;
             }
 
-            user.CreatedBy = user.Email;
+            user.CreatedBy = user.Email.Value;
 
             AuditLog log = new()
             {
@@ -32,7 +32,7 @@ namespace Myrtus.Clarity.Application.Features.Accounts.RegisterUser
                 Action = UserDomainEvents.Created,
                 Entity = user.GetType().Name,
                 EntityId = user.Id.ToString(),
-                Details = $"User with email '{user.Email}' created."
+                Details = $"User with email '{user.Email.Value}' created."
             };
             await _auditLogService.LogAsync(log);
         }

--- a/src/Myrtus.Clarity.Application/Features/Roles/Commands/Create/CreateRoleCommandHander.cs
+++ b/src/Myrtus.Clarity.Application/Features/Roles/Commands/Create/CreateRoleCommandHander.cs
@@ -41,7 +41,7 @@ namespace Myrtus.Clarity.Application.Features.Roles.Commands.Create
                 cancellationToken: cancellationToken);
             if (user is not null)
             {
-                role.CreatedBy = user.Email;
+                role.CreatedBy = user.Email.Value;
             }
 
             await _roleRepository.AddAsync(role);

--- a/src/Myrtus.Clarity.Application/Features/Roles/Commands/Delete/DeleteRoleCommandHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Roles/Commands/Delete/DeleteRoleCommandHandler.cs
@@ -39,7 +39,7 @@ namespace Myrtus.Clarity.Application.Features.Roles.Commands.Delete
                 cancellationToken: cancellationToken);
             if (user is not null)
             {
-                role.UpdatedBy = user.Email;
+                role.UpdatedBy = user.Email.Value;
             }
 
             try

--- a/src/Myrtus.Clarity.Application/Features/Roles/Commands/RegisterUserCommandValidator.cs
+++ b/src/Myrtus.Clarity.Application/Features/Roles/Commands/RegisterUserCommandValidator.cs
@@ -10,7 +10,7 @@ namespace Myrtus.Clarity.Application.Features.Accounts.RegisterUser
 
             RuleFor(c => c.LastName).NotEmpty();
 
-            RuleFor(c => c.Email).EmailAddress();
+            RuleFor(c => c.Email.Value).EmailAddress();
 
             RuleFor(c => c.Password).NotEmpty().MinimumLength(5);
         }

--- a/src/Myrtus.Clarity.Application/Features/Roles/Commands/Update/UpdatePermissions/UpdateRolePermissionsCommandHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Roles/Commands/Update/UpdatePermissions/UpdateRolePermissionsCommandHandler.cs
@@ -66,7 +66,7 @@ namespace Myrtus.Clarity.Application.Features.Roles.Commands.Update.UpdatePermis
             }
 
             User user = await _userService.GetUserByIdAsync(_userContext.UserId, cancellationToken);
-            role.UpdatedBy = user!.Email;
+            role.UpdatedBy = user!.Email.Value;
 
             _roleRepository.Update(role);
             await _unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/Myrtus.Clarity.Application/Features/Roles/Commands/Update/UpdateRoleName/UpdateRoleNameCommandHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Roles/Commands/Update/UpdateRoleName/UpdateRoleNameCommandHandler.cs
@@ -39,7 +39,7 @@ namespace Myrtus.Clarity.Application.Features.Roles.Commands.Update.UpdateRoleNa
             role.ChangeName(request.Name);
 
             User user = await _userService.GetUserByIdAsync(_userContext.UserId, cancellationToken);
-            role.UpdatedBy = user.Email;
+            role.UpdatedBy = user.Email.Value;
 
             _roleRepository.Update(role);
             await _unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/Myrtus.Clarity.Application/Features/Users/Commands/Update/UpdateUserRoles/AddUserRoleEventHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Commands/Update/UpdateUserRoles/AddUserRoleEventHandler.cs
@@ -32,7 +32,7 @@ namespace Myrtus.Clarity.Application.Features.Users.Commands.Update.UpdateUserRo
                 Action = UserDomainEvents.AddedRole,
                 Entity = user.GetType().Name,
                 EntityId = user.Id.ToString(),
-                Details = $"{user.GetType().Name} '{user.Email}' has been granted a new role '{role!.Name}'."
+                Details = $"{user.GetType().Name} '{user.Email.Value}' has been granted a new role '{role!.Name}'."
             };
             await _auditLogService.LogAsync(log);
         }

--- a/src/Myrtus.Clarity.Application/Features/Users/Commands/Update/UpdateUserRoles/RemoveUserRoleEventHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Commands/Update/UpdateUserRoles/RemoveUserRoleEventHandler.cs
@@ -33,7 +33,7 @@ namespace Myrtus.CMS.Application.Features.Users.Commands.Update.UpdateUserRoles
                 Action = UserDomainEvents.RemovedRole,
                 Entity = user.GetType().Name,
                 EntityId = user.Id.ToString(),
-                Details = $"{user.GetType().Name} '{user.Email}' has been revoked the role '{role!.Name}'."
+                Details = $"{user.GetType().Name} '{user.Email.Value}' has been revoked the role '{role!.Name}'."
             };
             await _auditLogService.LogAsync(log);
         }

--- a/src/Myrtus.Clarity.Application/Features/Users/Commands/Update/UpdateUserRoles/UpdateUserRolesCommandHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Commands/Update/UpdateUserRoles/UpdateUserRolesCommandHandler.cs
@@ -58,7 +58,7 @@ namespace Myrtus.Clarity.Application.Features.Users.Commands.Update.UpdateUserRo
             }
 
             User? modifierUser = await _userRepository.GetUserByIdAsync(_userContext.UserId, cancellationToken);
-            user.UpdatedBy = modifierUser!.Email ?? "System";
+            user.UpdatedBy = modifierUser!.Email.Value ?? "System";
 
             _userRepository.Update(user);
             await _unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsers/GetAllUsersQueryHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsers/GetAllUsersQueryHandler.cs
@@ -22,7 +22,8 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsers
                 include: user => user.Roles,
                 cancellationToken: cancellationToken);
 
-            List<GetAllUsersQueryResponse> mappedUsers = users.Items.Select(user => new GetAllUsersQueryResponse(
+            List<GetAllUsersQueryResponse> mappedUsers = users.Items.Select(
+                user => new GetAllUsersQueryResponse(
                 user.Id,
                 user.Email,
                 user.FirstName,

--- a/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsers/GetAllysersQueryResponse.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsers/GetAllysersQueryResponse.cs
@@ -1,4 +1,5 @@
 ﻿using Myrtus.Clarity.Application.Features.Users.Queries.GetLoggedInUser;
+using Myrtus.Clarity.Domain.Users.ValueObjects;
 using System.Collections.ObjectModel;
 
 namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsers
@@ -6,16 +7,16 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsers
     public sealed record GetAllUsersQueryResponse
     {
         public Guid Id { get; set; }
-        public string Email { get; set; } = string.Empty;
-        public string? FirstName { get; set; }
-        public string? LastName { get; set; }
+        public Email Email { get; set; }
+        public FirstName? FirstName { get; set; }
+        public LastName? LastName { get; set; }
         public ICollection<LoggedInUserRolesDto> Roles { get; set; } = [];
 
         public GetAllUsersQueryResponse(
             Guid id,
-            string email,
-            string? firstName,
-            string? lastName,
+            Email email,
+            FirstName? firstName,
+            LastName? lastName,
             Collection<LoggedInUserRolesDto> roles)
         {
             Id = id;
@@ -27,9 +28,9 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsers
 
         public GetAllUsersQueryResponse(
             Guid id,
-            string email,
-            string? firstName,
-            string? lastName)
+            Email email,
+            FirstName? firstName,
+            LastName? lastName)
         {
             Id = id;
             Email = email;

--- a/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersByRoleId/GetAllUsersByRoleIdQueryResponse.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersByRoleId/GetAllUsersByRoleIdQueryResponse.cs
@@ -1,4 +1,5 @@
 ﻿using Myrtus.Clarity.Application.Features.Users.Queries.GetLoggedInUser;
+using Myrtus.Clarity.Domain.Users.ValueObjects;
 using System.Collections.ObjectModel;
 
 namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsersByRoleId
@@ -6,16 +7,16 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsersByRoleId
     public sealed record GetAllUsersByRoleIdQueryResponse
     {
         public Guid Id { get; set; }
-        public string Email { get; set; } = string.Empty;
-        public string? FirstName { get; set; }
-        public string? LastName { get; set; }
+        public Email Email { get; set; } = new Email(string.Empty);
+        public FirstName? FirstName { get; set; }
+        public LastName? LastName { get; set; }
         public ICollection<LoggedInUserRolesDto> Roles { get; set; } = [];
 
         public GetAllUsersByRoleIdQueryResponse(
             Guid id,
-            string email,
-            string? firstName,
-            string? lastName,
+            Email email,
+            FirstName? firstName,
+            LastName? lastName,
             Collection<LoggedInUserRolesDto> roles)
         {
             Id = id;
@@ -25,7 +26,8 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsersByRoleId
             Roles = roles;
         }
 
-        public GetAllUsersByRoleIdQueryResponse(Guid id, string email, string? firstName, string? lastName)
+        public GetAllUsersByRoleIdQueryResponse(
+            Guid id, Email email, FirstName? firstName, LastName? lastName)
         {
             Id = id;
             Email = email;

--- a/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersDynamic/GetAllUsersDynamicQueryHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersDynamic/GetAllUsersDynamicQueryHandler.cs
@@ -24,7 +24,8 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsersDynamic
                     cancellationToken,
                     user => user.Roles);
 
-                List<GetAllUsersDynamicQueryResponse> mappedUsers = users.Items.Select(user => new GetAllUsersDynamicQueryResponse(
+                List<GetAllUsersDynamicQueryResponse> mappedUsers = users.Items.Select(
+                    user => new GetAllUsersDynamicQueryResponse(
                     user.Id,
                     user.Email,
                     user.FirstName,

--- a/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersDynamic/GetAllUsersDynamicQueryResponse.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersDynamic/GetAllUsersDynamicQueryResponse.cs
@@ -1,4 +1,5 @@
 ﻿using Myrtus.Clarity.Application.Features.Users.Queries.GetLoggedInUser;
+using Myrtus.Clarity.Domain.Users.ValueObjects;
 using System.Collections.ObjectModel;
 
 namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsersDynamic
@@ -6,16 +7,16 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsersDynamic
     public sealed record GetAllUsersDynamicQueryResponse
     {
         public Guid Id { get; init; }
-        public string Email { get; init; }
-        public string? FirstName { get; init; }
-        public string? LastName { get; init; }
+        public Email Email { get; init; }
+        public FirstName? FirstName { get; init; }
+        public LastName? LastName { get; init; }
         public ICollection<LoggedInUserRolesDto> Roles { get; init; } = [];
 
         public GetAllUsersDynamicQueryResponse(
             Guid id,
-            string email,
-            string? firstName,
-            string? lastName,
+            Email email,
+            FirstName? firstName,
+            LastName? lastName,
             Collection<LoggedInUserRolesDto> roles)
         {
             Id = id;

--- a/src/Myrtus.Clarity.Application/Features/Users/Queries/GetLoggedInUser/UserResponse.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Queries/GetLoggedInUser/UserResponse.cs
@@ -6,17 +6,17 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetLoggedInUser
     public sealed record UserResponse
     {
         public Guid Id { get; set; }
-        public string Email { get; set; } = string.Empty;
-        public string FirstName { get; set; } = string.Empty;
-        public string LastName { get; set; } = string.Empty;
+        public Email Email { get; set; }
+        public FirstName FirstName { get; set; }
+        public LastName LastName { get; set; }
         public ICollection<LoggedInUserRolesDto> Roles { get; set; } = [];
         public NotificationPreference NotificationPreference { get; set; }
 
         public UserResponse(
             Guid id,
-            string email,
-            string firstName,
-            string lastName,
+            Email email,
+            FirstName firstName,
+            LastName lastName,
             Collection<LoggedInUserRolesDto> roles,
             NotificationPreference notificationPreference)
         {

--- a/src/Myrtus.Clarity.Application/Features/Users/Queries/GetUser/GetUserQueryResponse.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Queries/GetUser/GetUserQueryResponse.cs
@@ -1,20 +1,21 @@
 ﻿using System.Collections.ObjectModel;
 using Myrtus.Clarity.Application.Features.Roles.Queries.GetRoleById;
+using Myrtus.Clarity.Domain.Users.ValueObjects;
 
 namespace Myrtus.Clarity.Application.Features.Users.Queries.GetUser
 {
     public sealed record GetUserQueryResponse
     {
         public Guid Id { get; set; }
-        public string Email { get; set; } = string.Empty;
-        public string? FirstName { get; set; }
-        public string? LastName { get; set; }
+        public Email Email { get; set; } = new Email(string.Empty);
+        public FirstName? FirstName { get; set; }
+        public LastName? LastName { get; set; }
         public ICollection<GetRoleByIdQueryResponse> Roles { get; set; } = [];
 
         public GetUserQueryResponse(Guid id,
-            string email,
-            string? firstName,
-            string? lastName,
+            Email email,
+            FirstName? firstName,
+            LastName? lastName,
             Collection<GetRoleByIdQueryResponse> roles)
         {
             Id = id;
@@ -24,7 +25,7 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetUser
             Roles = roles;
         }
 
-        public GetUserQueryResponse(Guid id, string email, string? firstName, string? lastName)
+        public GetUserQueryResponse(Guid id, Email email, FirstName? firstName, LastName? lastName)
         {
             Id = id;
             Email = email;

--- a/src/Myrtus.Clarity.Domain/Users/User.cs
+++ b/src/Myrtus.Clarity.Domain/Users/User.cs
@@ -7,10 +7,10 @@ namespace Myrtus.Clarity.Domain.Users
 {
     public sealed class User : Entity, IAggregateRoot
     {
-        private readonly List<Role> _roles = [];
-        public string FirstName { get; private set; }
-        public string LastName { get; private set; }
-        public string Email { get; private set; }
+        private readonly List<Role> _roles = new();
+        public FirstName FirstName { get; private set; }
+        public LastName LastName { get; private set; }
+        public Email Email { get; private set; }
         public string IdentityId { get; private set; } = string.Empty;
         public NotificationPreference NotificationPreference { get; private set; }
 
@@ -18,9 +18,9 @@ namespace Myrtus.Clarity.Domain.Users
 
         private User(
             Guid id,
-            string firstName,
-            string lastName,
-            string email,
+            FirstName firstName,
+            LastName lastName,
+            Email email,
             NotificationPreference notificationPreference) : base(id)
         {
             FirstName = firstName;
@@ -31,14 +31,14 @@ namespace Myrtus.Clarity.Domain.Users
 
         private User()
         {
-            FirstName = string.Empty;
-            LastName = string.Empty;
-            Email = string.Empty;
+            FirstName = new FirstName("DefaultFirstName");
+            LastName = new LastName("DefaultLastName");
+            Email = new Email("default@example.com");
         }
 
-        public static User Create(string firstName,
-            string lastName,
-            string email)
+        public static User Create(FirstName firstName,
+            LastName lastName,
+            Email email)
         {
             NotificationPreference notificationPreference = new(true, true, true);
             User user = new(Guid.NewGuid(), firstName, lastName, email, notificationPreference);
@@ -49,9 +49,9 @@ namespace Myrtus.Clarity.Domain.Users
         }
 
         public static User CreateWithoutRolesForSeeding(
-            string firstName,
-            string lastName,
-            string email)
+            FirstName firstName,
+            LastName lastName,
+            Email email)
         {
             NotificationPreference notificationPreference = new(true, true, true);
             return new User(Guid.NewGuid(), firstName, lastName, email, notificationPreference);

--- a/src/Myrtus.Clarity.Domain/Users/ValueObjects/Email.cs
+++ b/src/Myrtus.Clarity.Domain/Users/ValueObjects/Email.cs
@@ -1,0 +1,37 @@
+﻿using Myrtus.Clarity.Core.Domain.Abstractions;
+using System.Text.RegularExpressions;
+
+namespace Myrtus.Clarity.Domain.Users.ValueObjects
+{
+    public class Email : ValueObject
+    {
+        private static readonly Regex EmailRegex = new(@"^[^@\s]+@[^@\s]+\.[^@\s]+$", RegexOptions.Compiled);
+
+        public string Value { get; }
+
+        public Email(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("Email cannot be empty", nameof(value));
+            }
+
+            if (!EmailRegex.IsMatch(value))
+            {
+                throw new ArgumentException("Invalid email format", nameof(value));
+            }
+
+            Value = value;
+        }
+
+        protected override IEnumerable<object?> GetEqualityComponents()
+        {
+            yield return Value;
+        }
+
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
+}

--- a/src/Myrtus.Clarity.Domain/Users/ValueObjects/FirstName.cs
+++ b/src/Myrtus.Clarity.Domain/Users/ValueObjects/FirstName.cs
@@ -1,0 +1,39 @@
+﻿using Myrtus.Clarity.Core.Domain.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Myrtus.Clarity.Domain.Users.ValueObjects
+{
+    public class FirstName : ValueObject
+    {
+        public string Value { get; }
+
+        public FirstName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("First name cannot be empty", nameof(value));
+            }
+
+            if (value.Length > 50)
+            {
+                throw new ArgumentException("First name cannot be longer than 50 characters", nameof(value));
+            }
+
+            Value = value;
+        }
+
+        protected override IEnumerable<object?> GetEqualityComponents()
+        {
+            yield return Value;
+        }
+
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
+}

--- a/src/Myrtus.Clarity.Domain/Users/ValueObjects/LastName.cs
+++ b/src/Myrtus.Clarity.Domain/Users/ValueObjects/LastName.cs
@@ -1,0 +1,34 @@
+﻿using Myrtus.Clarity.Core.Domain.Abstractions;
+
+namespace Myrtus.Clarity.Domain.Users.ValueObjects
+{
+    public class LastName : ValueObject
+    {
+        public string Value { get; }
+
+        public LastName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("Last name cannot be empty", nameof(value));
+            }
+
+            if (value.Length > 50)
+            {
+                throw new ArgumentException("Last name cannot be longer than 50 characters", nameof(value));
+            }
+
+            Value = value;
+        }
+
+        protected override IEnumerable<object?> GetEqualityComponents()
+        {
+            yield return Value;
+        }
+
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
+}

--- a/src/Myrtus.Clarity.Infrastructure/Authentication/AzureAuthService.cs
+++ b/src/Myrtus.Clarity.Infrastructure/Authentication/AzureAuthService.cs
@@ -67,15 +67,15 @@ namespace Myrtus.Clarity.Infrastructure.Authentication
                 {
                     AccountEnabled = true,
                     DisplayName = $"{user.FirstName} {user.LastName}",
-                    GivenName = user.FirstName,
-                    Surname = user.LastName,
+                    GivenName = user.FirstName.Value,
+                    Surname = user.LastName.Value,
                     Identities = new List<ObjectIdentity>
                         {
                             new ObjectIdentity
                             {
                                 SignInType = "emailAddress",
                                 Issuer = _configuration["AzureAd:Domain"],
-                                IssuerAssignedId = user.Email
+                                IssuerAssignedId = user.Email.Value
                             }
                         },
                     PasswordProfile = new PasswordProfile
@@ -128,7 +128,7 @@ namespace Myrtus.Clarity.Infrastructure.Authentication
                     {"scope", "openid"},
                     {"response_type", "code"},
                     {"prompt", "login"},
-                    {"login_hint", user.Email},
+                    {"login_hint", user.Email.Value},
                     {"code_challenge", codeChallenge},
                     {"code_challenge_method", "S256"}
                 };
@@ -159,7 +159,7 @@ namespace Myrtus.Clarity.Infrastructure.Authentication
                         new MailboxAddress(
                             encoding: Encoding.UTF8,
                             name: $"{user.FirstName} {user.LastName}",
-                            address: user.Email)
+                            address: user.Email.Value)
                 });
 
             // Send the email using IMailService

--- a/src/Myrtus.Clarity.Infrastructure/Authentication/Models/UserRepresentationModel.cs
+++ b/src/Myrtus.Clarity.Infrastructure/Authentication/Models/UserRepresentationModel.cs
@@ -1,5 +1,6 @@
 ﻿using Myrtus.Clarity.Core.Infrastructure.Authentication.Azure.Models;
 using Myrtus.Clarity.Domain.Users;
+using Myrtus.Clarity.Domain.Users.ValueObjects;
 
 namespace Myrtus.Clarity.Infrastructure.Authentication.Models
 {
@@ -17,7 +18,7 @@ namespace Myrtus.Clarity.Infrastructure.Authentication.Models
 
         public string[] DisableableCredentialTypes { get; set; } = [];
 
-        public string Email { get; set; } = string.Empty;
+        public Email Email { get; set; } = new Email(string.Empty);
 
         public bool? EmailVerified { get; set; }
 
@@ -29,9 +30,9 @@ namespace Myrtus.Clarity.Infrastructure.Authentication.Models
 
         public string[] Groups { get; set; } = [];
 
-        public string FirstName { get; set; } = string.Empty;
+        public FirstName FirstName { get; set; } = new FirstName(string.Empty);
 
-        public string LastName { get; set; } = string.Empty;
+        public LastName LastName { get; set; } = new LastName(string.Empty);
 
         public int? NotBefore { get; set; }
 
@@ -53,7 +54,7 @@ namespace Myrtus.Clarity.Infrastructure.Authentication.Models
                 FirstName = user.FirstName,
                 LastName = user.LastName,
                 Email = user.Email,
-                Username = user.Email,
+                Username = user.Email.Value,
                 Enabled = true,
                 EmailVerified = true,
                 CreatedTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),

--- a/src/Myrtus.Clarity.Infrastructure/Configurations/UserConfiguration.cs
+++ b/src/Myrtus.Clarity.Infrastructure/Configurations/UserConfiguration.cs
@@ -6,13 +6,27 @@ namespace Myrtus.Clarity.Infrastructure.Configurations
 {
     internal sealed class UserConfiguration : IEntityTypeConfiguration<User>
     {
-        public static Guid AdminId { get; }
-
         public void Configure(EntityTypeBuilder<User> builder)
         {
             builder.ToTable("users");
             builder.HasKey(user => user.Id);
-            builder.HasIndex(user => user.Email).IsUnique();
+
+            builder.OwnsOne(user => user.FirstName, firstName =>
+            {
+                firstName.Property(f => f.Value).HasColumnName("first_name");
+            });
+
+            builder.OwnsOne(user => user.LastName, lastName =>
+            {
+                lastName.Property(l => l.Value).HasColumnName("last_name");
+            });
+
+            builder.OwnsOne(user => user.Email, email =>
+            {
+                email.Property(e => e.Value).HasColumnName("email");
+                email.HasIndex(e => e.Value).IsUnique();
+            });
+
             builder.HasIndex(user => user.IdentityId).IsUnique();
 
             builder.OwnsOne(user => user.NotificationPreference, np =>

--- a/src/Myrtus.Clarity.Infrastructure/Migrations/20241222202542_createEmailValueObject.Designer.cs
+++ b/src/Myrtus.Clarity.Infrastructure/Migrations/20241222202542_createEmailValueObject.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Myrtus.Clarity.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Myrtus.Clarity.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241222202542_createEmailValueObject")]
+    partial class createEmailValueObject
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -164,10 +167,20 @@ namespace Myrtus.Clarity.Infrastructure.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("deleted_on_utc");
 
+                    b.Property<string>("FirstName")
+                        .IsRequired()
+                        .HasColumnType("text")
+                        .HasColumnName("first_name");
+
                     b.Property<string>("IdentityId")
                         .IsRequired()
                         .HasColumnType("text")
                         .HasColumnName("identity_id");
+
+                    b.Property<string>("LastName")
+                        .IsRequired()
+                        .HasColumnType("text")
+                        .HasColumnName("last_name");
 
                     b.Property<string>("UpdatedBy")
                         .HasColumnType("text")
@@ -227,7 +240,7 @@ namespace Myrtus.Clarity.Infrastructure.Migrations
 
             modelBuilder.Entity("Myrtus.Clarity.Domain.Users.User", b =>
                 {
-                    b.OwnsOne("Myrtus.Clarity.Domain.Users.ValueObjects.Email", "Email", b1 =>
+                    b.OwnsOne("Myrtus.Clarity.Domain.Users.Email", "Email", b1 =>
                         {
                             b1.Property<Guid>("UserId")
                                 .HasColumnType("uuid")
@@ -243,46 +256,6 @@ namespace Myrtus.Clarity.Infrastructure.Migrations
                             b1.HasIndex("Value")
                                 .IsUnique()
                                 .HasDatabaseName("ix_users_email");
-
-                            b1.ToTable("users");
-
-                            b1.WithOwner()
-                                .HasForeignKey("UserId")
-                                .HasConstraintName("fk_users_users_id");
-                        });
-
-                    b.OwnsOne("Myrtus.Clarity.Domain.Users.ValueObjects.FirstName", "FirstName", b1 =>
-                        {
-                            b1.Property<Guid>("UserId")
-                                .HasColumnType("uuid")
-                                .HasColumnName("id");
-
-                            b1.Property<string>("Value")
-                                .IsRequired()
-                                .HasColumnType("text")
-                                .HasColumnName("first_name");
-
-                            b1.HasKey("UserId");
-
-                            b1.ToTable("users");
-
-                            b1.WithOwner()
-                                .HasForeignKey("UserId")
-                                .HasConstraintName("fk_users_users_id");
-                        });
-
-                    b.OwnsOne("Myrtus.Clarity.Domain.Users.ValueObjects.LastName", "LastName", b1 =>
-                        {
-                            b1.Property<Guid>("UserId")
-                                .HasColumnType("uuid")
-                                .HasColumnName("id");
-
-                            b1.Property<string>("Value")
-                                .IsRequired()
-                                .HasColumnType("text")
-                                .HasColumnName("last_name");
-
-                            b1.HasKey("UserId");
 
                             b1.ToTable("users");
 
@@ -319,12 +292,6 @@ namespace Myrtus.Clarity.Infrastructure.Migrations
                         });
 
                     b.Navigation("Email")
-                        .IsRequired();
-
-                    b.Navigation("FirstName")
-                        .IsRequired();
-
-                    b.Navigation("LastName")
                         .IsRequired();
 
                     b.Navigation("NotificationPreference")

--- a/src/Myrtus.Clarity.Infrastructure/Migrations/20241222202542_createEmailValueObject.cs
+++ b/src/Myrtus.Clarity.Infrastructure/Migrations/20241222202542_createEmailValueObject.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Myrtus.Clarity.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class createEmailValueObject : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/Myrtus.Clarity.Infrastructure/Migrations/20241222210250_createFirstLastNameValueObjects.Designer.cs
+++ b/src/Myrtus.Clarity.Infrastructure/Migrations/20241222210250_createFirstLastNameValueObjects.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Myrtus.Clarity.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Myrtus.Clarity.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241222210250_createFirstLastNameValueObjects")]
+    partial class createFirstLastNameValueObjects
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Myrtus.Clarity.Infrastructure/Migrations/20241222210250_createFirstLastNameValueObjects.cs
+++ b/src/Myrtus.Clarity.Infrastructure/Migrations/20241222210250_createFirstLastNameValueObjects.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Myrtus.Clarity.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class createFirstLastNameValueObjects : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/Myrtus.Clarity.Infrastructure/SeedData/SeedUsers.cs
+++ b/src/Myrtus.Clarity.Infrastructure/SeedData/SeedUsers.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Myrtus.Clarity.Core.Application.Abstractions.Data.Dapper;
 using Myrtus.Clarity.Domain.Users;
 using Myrtus.Clarity.Domain.Roles;
+using Myrtus.Clarity.Domain.Users.ValueObjects;
 
 namespace Myrtus.Clarity.Infrastructure.SeedData
 {
@@ -25,9 +26,9 @@ namespace Myrtus.Clarity.Infrastructure.SeedData
             using IDbConnection connection = sqlConnectionFactory.CreateConnection();
 
             User adminUser = User.CreateWithoutRolesForSeeding(
-                "Admin",
-                "Admin",
-                "admin@email.com");
+                new FirstName("Admin"),
+                new LastName("User"),
+                new Email("admin@email.com"));
 
             adminUser.SetIdentityId("5a7e3a65-0515-45a7-8c4c-f17a03efd851");
             AdminId = adminUser.Id;
@@ -35,9 +36,9 @@ namespace Myrtus.Clarity.Infrastructure.SeedData
             var adminUserDto = new
             {
                 adminUser.Id,
-                adminUser.FirstName,
-                adminUser.LastName,
-                adminUser.Email,
+                FirstName = adminUser.FirstName.Value,
+                LastName = adminUser.LastName.Value,
+                Email = adminUser.Email.Value,
                 adminUser.IdentityId,
                 adminUser.CreatedBy,
                 CreatedOnUtc = DateTime.UtcNow
@@ -45,24 +46,24 @@ namespace Myrtus.Clarity.Infrastructure.SeedData
 
             const string userSql =
                 """
-                INSERT INTO users (id, first_name, last_name, email, identity_id, created_by, created_on_utc)
-                VALUES (@Id, @FirstName, @LastName, @Email, @IdentityId, @CreatedBy, @CreatedOnUtc)
-                ON CONFLICT (id) DO NOTHING; -- Avoid duplicate entries
-                """;
+                    INSERT INTO users (id, first_name, last_name, email, identity_id, created_by, created_on_utc)
+                    VALUES (@Id, @FirstName, @LastName, @Email, @IdentityId, @CreatedBy, @CreatedOnUtc)
+                    ON CONFLICT (id) DO NOTHING; -- Avoid duplicate entries
+                    """;
             await connection.ExecuteAsync(userSql, adminUserDto);
 
-            List<object> roleUsers =
-                [
-                        new { RoleId = Role.DefaultRole.Id, UserId = adminUser.Id },
-                        new { RoleId = Role.Admin.Id, UserId = adminUser.Id }
-                ];
+            List<object> roleUsers = new List<object>
+                {
+                    new { RoleId = Role.DefaultRole.Id, UserId = adminUser.Id },
+                    new { RoleId = Role.Admin.Id, UserId = adminUser.Id }
+                };
 
             const string roleSql =
                 """
-                INSERT INTO role_user (roles_id, users_id)
-                VALUES(@RoleId, @UserId)
-                ON CONFLICT (roles_id, users_id) DO NOTHING;
-                """;
+                    INSERT INTO role_user (roles_id, users_id)
+                    VALUES(@RoleId, @UserId)
+                    ON CONFLICT (roles_id, users_id) DO NOTHING;
+                    """;
             await connection.ExecuteAsync(roleSql, roleUsers);
 
             return AdminId;

--- a/src/Myrtus.Clarity.SeedData/Myrtus.Clarity.SeedData.csproj
+++ b/src/Myrtus.Clarity.SeedData/Myrtus.Clarity.SeedData.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
   </ItemGroup>

--- a/src/Myrtus.Clarity.WebAPI/Controllers/Accounts/RegisterUserRequest.cs
+++ b/src/Myrtus.Clarity.WebAPI/Controllers/Accounts/RegisterUserRequest.cs
@@ -1,8 +1,10 @@
-﻿namespace Myrtus.Clarity.WebAPI.Controllers.Accounts
+﻿using Myrtus.Clarity.Domain.Users.ValueObjects;
+
+namespace Myrtus.Clarity.WebAPI.Controllers.Accounts
 {
     public sealed record RegisterUserRequest(
-        string Email,
-        string FirstName,
-        string LastName,
+        Email Email,
+        FirstName FirstName,
+        LastName LastName,
         string Password);
 }

--- a/src/Myrtus.Clarity.WebAPI/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/Myrtus.Clarity.WebAPI/Middleware/ExceptionHandlingMiddleware.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 
 namespace Myrtus.Clarity.WebAPI.Middleware
 {
-    internal sealed class ExceptionHandlingMiddleware(
+    public sealed class ExceptionHandlingMiddleware(
                 RequestDelegate next,
                 ILogger<ExceptionHandlingMiddleware> logger)
     {


### PR DESCRIPTION
Introduce value objects for Email, FirstName, and LastName in the Myrtus.Clarity.Domain.Users.ValueObjects namespace, encapsulating validation logic. Update RegisterUserCommand, User entity, query response classes, and validators to use these value objects.

Update AzureAuthService, UserRepresentationModel, and UserConfiguration to handle new value objects. Add migration for database schema changes. Modify seeding logic and SQL insert statements to align with new structure. Update RegisterUserRequest to use value objects.

Make ExceptionHandlingMiddleware class public. Add EF Core design package reference.