### PR TITLE
feat:Add NotificationsUpdate permission and update seed data

### DIFF
--- a/src/Myrtus.Clarity.Domain/Roles/Permission.cs
+++ b/src/Myrtus.Clarity.Domain/Roles/Permission.cs
@@ -20,6 +20,7 @@ namespace Myrtus.Clarity.Domain.Roles
         public static readonly Permission AuditLogsRead = new(Guid.Parse("3050d953-5dcf-4eb0-a18d-a3ce62a0dd3c"), "auditlogs", "auditlogs:read");
 
         public static readonly Permission NotificationsRead = new(Guid.Parse("a03a127b-9a03-46a0-b709-b6919f2598be"), "notifications", "notifications:read");
+        public static readonly Permission NotificationsUpdate = new(Guid.Parse("a5585e9e-ec65-431b-9bb9-9bbc1663ebb8"), "notifications", "notifications:update");
         public Permission(Guid id, string feature, string name) : base(id)
         {
             Feature = feature;

--- a/src/Myrtus.Clarity.Infrastructure/SeedData/SeedPermissions.cs
+++ b/src/Myrtus.Clarity.Infrastructure/SeedData/SeedPermissions.cs
@@ -27,7 +27,8 @@ namespace Myrtus.Clarity.Infrastructure.SeedData
                     Permission.RolesDelete,
                     Permission.PermissionsRead,
                     Permission.AuditLogsRead,
-                    Permission.NotificationsRead
+                    Permission.NotificationsRead,
+                    Permission.NotificationsUpdate,
             ];
 
             const string sql =

--- a/src/Myrtus.Clarity.Infrastructure/SeedData/SeedRolePermissions.cs
+++ b/src/Myrtus.Clarity.Infrastructure/SeedData/SeedRolePermissions.cs
@@ -19,6 +19,7 @@ namespace Myrtus.Clarity.Infrastructure.SeedData
                 [
                     new { RoleId = Role.DefaultRole.Id, PermissionId = Permission.UsersRead.Id },
                     new { RoleId = Role.DefaultRole.Id, PermissionId = Permission.NotificationsRead.Id },
+                    new { RoleId = Role.DefaultRole.Id, PermissionId = Permission.NotificationsUpdate.Id },
                     new { RoleId = Role.Admin.Id, PermissionId = Permission.UsersRead.Id },
                     new { RoleId = Role.Admin.Id, PermissionId = Permission.UsersCreate.Id },
                     new { RoleId = Role.Admin.Id, PermissionId = Permission.UsersUpdate.Id },
@@ -29,7 +30,8 @@ namespace Myrtus.Clarity.Infrastructure.SeedData
                     new { RoleId = Role.Admin.Id, PermissionId = Permission.RolesDelete.Id },
                     new { RoleId = Role.Admin.Id, PermissionId = Permission.PermissionsRead.Id },
                     new { RoleId = Role.Admin.Id, PermissionId = Permission.AuditLogsRead.Id },
-                    new { RoleId = Role.Admin.Id, PermissionId = Permission.NotificationsRead.Id }
+                    new { RoleId = Role.Admin.Id, PermissionId = Permission.NotificationsRead.Id },
+                    new { RoleId = Role.Admin.Id, PermissionId = Permission.NotificationsUpdate.Id }
                 ];
 
             const string sql =

--- a/src/Myrtus.Clarity.WebAPI/Controllers/Notifications/NotificationsController.cs
+++ b/src/Myrtus.Clarity.WebAPI/Controllers/Notifications/NotificationsController.cs
@@ -34,7 +34,7 @@ namespace Myrtus.Clarity.WebAPI.Controllers.Notifications
         }
 
         [HttpPatch("read")]
-        //[HasPermission(Permissions.NotificationsUpdate)]
+        [HasPermission(Permissions.NotificationsUpdate)]
         public async Task<IActionResult> MarkNotificationsAsRead(
             CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Introduced a new permission `NotificationsUpdate` to manage update operations on notifications. Updated `SeedPermissions.cs` and `SeedRolePermissions.cs` to include and assign this permission to `DefaultRole` and `Admin` roles. Enabled the `[HasPermission(Permissions.NotificationsUpdate)]` attribute in the `MarkNotificationsAsRead` method of `NotificationsController` to enforce permission checks.