### PR TITLE
refactor! user properties to use string types

### DIFF
--- a/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersDynamic/GetAllUsersDynamicQueryHandler.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersDynamic/GetAllUsersDynamicQueryHandler.cs
@@ -27,9 +27,9 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsersDynamic
                 List<GetAllUsersDynamicQueryResponse> mappedUsers = users.Items.Select(
                     user => new GetAllUsersDynamicQueryResponse(
                     user.Id,
-                    user.Email,
-                    user.FirstName,
-                    user.LastName,
+                    user.Email.Value,
+                    user.FirstName.Value,
+                    user.LastName.Value,
                     new Collection<LoggedInUserRolesDto>(
                         user.Roles
                             .Where(role => role.DeletedOnUtc == null)

--- a/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersDynamic/GetAllUsersDynamicQueryResponse.cs
+++ b/src/Myrtus.Clarity.Application/Features/Users/Queries/GetAllUsersDynamic/GetAllUsersDynamicQueryResponse.cs
@@ -7,16 +7,16 @@ namespace Myrtus.Clarity.Application.Features.Users.Queries.GetAllUsersDynamic
     public sealed record GetAllUsersDynamicQueryResponse
     {
         public Guid Id { get; init; }
-        public Email Email { get; init; }
-        public FirstName? FirstName { get; init; }
-        public LastName? LastName { get; init; }
+        public string Email { get; init; }
+        public string? FirstName { get; init; }
+        public string? LastName { get; init; }
         public ICollection<LoggedInUserRolesDto> Roles { get; init; } = [];
 
         public GetAllUsersDynamicQueryResponse(
             Guid id,
-            Email email,
-            FirstName? firstName,
-            LastName? lastName,
+            string email,
+            string? firstName,
+            string? lastName,
             Collection<LoggedInUserRolesDto> roles)
         {
             Id = id;


### PR DESCRIPTION
Modified `Email`, `FirstName`, and `LastName` properties in `GetAllUsersDynamicQueryHandler.cs` and `GetAllUsersDynamicQueryResponse.cs` from custom types to standard `string` types. Updated property definitions and constructor parameters accordingly. The `using System.Collections.ObjectModel;` statement remains unchanged.